### PR TITLE
Minor changes for the integration of Azure B2C

### DIFF
--- a/OP.md
+++ b/OP.md
@@ -22,6 +22,24 @@ def get_azure_django_username(claims):
 
 `oid` is a special Azure Object ID that uniquely identify the user.
 
+Azure B2C
+---------
+Azure B2C does not offer a termination point for user. 
+The configuration is similar to that of Azure AD but requires some small
+changes.
+
+
+| Setting | Value |
+| ------- | ----- |
+| `OIDC_OP_DISCOVERY_DOCUMENT_URL` | `'https://login.microsoftonline.com/<tenant_id>/v2.0/.well-known/openid-configuration'` |
+| `OIDC_DJANGO_USERNAME_FUNC` | `'myapp.utils.get_azure_django_username'` |
+| `OIDC_FIRSTNAME_CLAIM` | `lambda x: x['given_name']`|
+| `OIDC_LASTNAME_CLAIM` | `lambda x: x['family_name']`|
+| `OIDC_EMAIL_CLAIM` | `lambda x: x['emails']`|
+| `OIDC_IGNORE_USERINFO_URL` | `True`|
+| `OIDC_EMAIL_CLAIM_KEY` | `'emails'`|
+
+
 Gitlab
 ------
 

--- a/OP.md
+++ b/OP.md
@@ -31,7 +31,7 @@ changes.
 
 | Setting | Value |
 | ------- | ----- |
-| `OIDC_OP_DISCOVERY_DOCUMENT_URL` | `'https://login.microsoftonline.com/<tenant_id>/v2.0/.well-known/openid-configuration'` |
+| `OIDC_OP_DISCOVERY_DOCUMENT_URL` | `'https://<azure_b2c_endpoint>/v2.0/.well-known/openid-configuration'` |
 | `OIDC_DJANGO_USERNAME_FUNC` | `'myapp.utils.get_azure_django_username'` |
 | `OIDC_FIRSTNAME_CLAIM` | `lambda x: x['given_name']`|
 | `OIDC_LASTNAME_CLAIM` | `lambda x: x['family_name']`|

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
-                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.11.8"
+            "version": "==2020.12.5"
         },
         "cffi": {
             "hashes": [
@@ -48,17 +48,20 @@
                 "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
                 "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
                 "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
+                "sha256:7ef7d4ced6b325e92eb4d3502946c78c5367bc416398d387b39591532536734e",
                 "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
                 "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
                 "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
                 "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
                 "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
+                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
                 "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
                 "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
                 "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
                 "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
                 "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
                 "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
+                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
                 "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
                 "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
                 "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
@@ -78,31 +81,23 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:22f8251f68953553af4f9c11ec5f191198bc96cff9f0ac5dd5ff94daede0ee6d",
-                "sha256:284e275e3c099a80831f9898fb5c9559120d27675c3521278faba54e584a7832",
-                "sha256:3e17d02941c0f169c5b877597ca8be895fca0e5e3eb882526a74aa4804380a98",
-                "sha256:52a47e60953679eea0b4d490ca3c241fb1b166a7b161847ef4667dfd49e7699d",
-                "sha256:57b8c1ed13b8aa386cabbfde3be175d7b155682470b0e259fecfe53850967f8a",
-                "sha256:6a8f64ed096d13f92d1f601a92d9fd1f1025dc73a2ca1ced46dcf5e0d4930943",
-                "sha256:6e8a3c7c45101a7eeee93102500e1b08f2307c717ff553fcb3c1127efc9b6917",
-                "sha256:7ef41304bf978f33cfb6f43ca13bb0faac0c99cda33693aa20ad4f5e34e8cb8f",
-                "sha256:87c2fffd61e934bc0e2c927c3764c20b22d7f5f7f812ee1a477de4c89b044ca6",
-                "sha256:88069392cd9a1e68d2cfd5c3a2b0d72a44ef3b24b8977a4f7956e9e3c4c9477a",
-                "sha256:8a0866891326d3badb17c5fd3e02c926b635e8923fa271b4813cd4d972a57ff3",
-                "sha256:8f0fd8b0751d75c4483c534b209e39e918f0d14232c0d8a2a76e687f64ced831",
-                "sha256:9a07e6d255053674506091d63ab4270a119e9fc83462c7ab1dbcb495b76307af",
-                "sha256:9a8580c9afcdcddabbd064c0a74f337af74ff4529cdf3a12fa2e9782d677a2e5",
-                "sha256:bd80bc156d3729b38cb227a5a76532aef693b7ac9e395eea8063ee50ceed46a5",
-                "sha256:d1cbc3426e6150583b22b517ef3720036d7e3152d428c864ff0f3fcad2b97591",
-                "sha256:e15ac84dcdb89f92424cbaca4b0b34e211e7ce3ee7b0ec0e4f3c55cee65fae5a",
-                "sha256:e4789b84f8dedf190148441f7c5bfe7244782d9cbb194a36e17b91e7d3e1cca9",
-                "sha256:f01c9116bfb3ad2831e125a73dcd957d173d6ddca7701528eff1e7d97972872c",
-                "sha256:f0e3986f6cce007216b23c490f093f35ce2068f3c244051e559f647f6731b7ae",
-                "sha256:f2aa3f8ba9e2e3fd49bd3de743b976ab192fbf0eb0348cebde5d2a9de0090a9f",
-                "sha256:fb70a4cedd69dc52396ee114416a3656e011fb0311fca55eb55c7be6ed9c8aef"
+                "sha256:0d7b69674b738068fa6ffade5c962ecd14969690585aaca0a1b1fc9058938a72",
+                "sha256:1bd0ccb0a1ed775cd7e2144fe46df9dc03eefd722bbcf587b3e0616ea4a81eff",
+                "sha256:3c284fc1e504e88e51c428db9c9274f2da9f73fdf5d7e13a36b8ecb039af6e6c",
+                "sha256:49570438e60f19243e7e0d504527dd5fe9b4b967b5a1ff21cc12b57602dd85d3",
+                "sha256:541dd758ad49b45920dda3b5b48c968f8b2533d8981bcdb43002798d8f7a89ed",
+                "sha256:5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed",
+                "sha256:7951a966613c4211b6612b0352f5bf29989955ee592c4a885d8c7d0f830d0433",
+                "sha256:922f9602d67c15ade470c11d616f2b2364950602e370c76f0c94c94ae672742e",
+                "sha256:a0f0b96c572fc9f25c3f4ddbf4688b9b38c69836713fb255f4a2715d93cbaf44",
+                "sha256:a777c096a49d80f9d2979695b835b0f9c9edab73b59e4ceb51f19724dda887ed",
+                "sha256:a9a4ac9648d39ce71c2f63fe7dc6db144b9fa567ddfc48b9fde1b54483d26042",
+                "sha256:aa4969f24d536ae2268c902b2c3d62ab464b5a66bcb247630d208a79a8098e9b",
+                "sha256:c7390f9b2119b2b43160abb34f63277a638504ef8df99f11cb52c1fda66a2e6f",
+                "sha256:e18e6ab84dfb0ab997faf8cca25a86ff15dfea4027b986322026cc99e0a892da"
             ],
             "index": "pypi",
-            "version": "==3.2"
+            "version": "==3.3.2"
         },
         "django": {
             "hashes": [
@@ -153,10 +148,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
-                "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2020.4"
+            "version": "==2021.1"
         },
         "requests": {
             "hashes": [
@@ -168,10 +163,10 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa",
-                "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"
+                "sha256:69805d6b69f56eb05b62daea3a7dbd7aa44324ad1306445e05da8060232d00f4",
+                "sha256:a8774e55b59fd9fc893b0d05e9bfc6f47081f46ff5b46f39ccf24631b7be356b"
             ],
-            "version": "==4.6"
+            "version": "==4.7"
         },
         "six": {
             "hashes": [

--- a/src/oauth2_authcodeflow/conf.py
+++ b/src/oauth2_authcodeflow/conf.py
@@ -17,7 +17,8 @@ def import_string_if_not_func(value: Union[str, Callable], attr: str) -> Callabl
     try:
         return value if callable(value) else import_string(value)
     except ImportError as e:
-        raise ImportError(f"Could not import '{value}' for API setting '{attr}'. {e.__class__.__name__}: {e}.")
+        raise ImportError(
+            f"Could not import '{value}' for API setting '{attr}'. {e.__class__.__name__}: {e}.")
 
 
 def get_default_django_username(claims: Dict) -> str:
@@ -104,6 +105,7 @@ DEFAULTS = {
     # The default is to use a base64 encode of the email hash (sha1).
     'OIDC_DJANGO_USERNAME_FUNC': get_default_django_username,
     'OIDC_EMAIL_CLAIM': 'email',
+    'OIDC_EMAIL_CLAIM_KEY': 'email',
     # You can also provide a lambda that takes all the claims as argument and return a firstname
     'OIDC_FIRSTNAME_CLAIM': 'given_name',
     # You can also provide a lambda that takes all the claims as argument and return a lastname
@@ -120,6 +122,7 @@ DEFAULTS = {
     # Expected list of regexp URL patterns.
     'OIDC_MIDDLEWARE_API_URL_PATTERNS': ['^/api/'],
     'OIDC_MIDDLEWARE_SESSION_TIMEOUT_SECONDS': 7 * 86400,  # 7 days
+    'OIDC_IGNORE_USERINFO_URL': False
 }
 # settings that may be in dotted string import notation and should be transformed in a lazy way.
 IMPORT_STRINGS = [
@@ -137,6 +140,7 @@ class Settings:
     A settings object, that allows settings to be accessed as properties.
     Any setting with dotted string import paths will be resolved to the callable.
     """
+
     def __init__(self, defaults=None, import_strings=None):
         self.defaults = defaults or DEFAULTS
         self.import_strings = import_strings or IMPORT_STRINGS

--- a/src/oauth2_authcodeflow/utils.py
+++ b/src/oauth2_authcodeflow/utils.py
@@ -39,7 +39,10 @@ class OIDCUrlsMixin:
                 session_conf = getattr(constants, 'SESSION_' + conf)
                 if session_conf not in session:
                     session[session_conf] = getattr(settings, 'OIDC_' + conf)
-        for conf in ('OP_AUTHORIZATION_URL', 'OP_TOKEN_URL'):#, 'OP_USERINFO_URL'
+        confs = ['OP_AUTHORIZATION_URL', 'OP_TOKEN_URL']
+        if not settings.OIDC_IGNORE_USERINFO_URL:
+            confs.append('OP_USERINFO_URL')
+        for conf in confs:
             session_conf = getattr(constants, 'SESSION_' + conf)
             if not session.get(session_conf):
                 raise ImproperlyConfigured(f'OIDC_{conf} is undefined')

--- a/src/oauth2_authcodeflow/utils.py
+++ b/src/oauth2_authcodeflow/utils.py
@@ -39,7 +39,7 @@ class OIDCUrlsMixin:
                 session_conf = getattr(constants, 'SESSION_' + conf)
                 if session_conf not in session:
                     session[session_conf] = getattr(settings, 'OIDC_' + conf)
-        for conf in ('OP_AUTHORIZATION_URL', 'OP_TOKEN_URL', 'OP_USERINFO_URL'):
+        for conf in ('OP_AUTHORIZATION_URL', 'OP_TOKEN_URL'):#, 'OP_USERINFO_URL'
             session_conf = getattr(constants, 'SESSION_' + conf)
             if not session.get(session_conf):
                 raise ImproperlyConfigured(f'OIDC_{conf} is undefined')


### PR DESCRIPTION
Azure B2C does not offer a termination point for user (see the oidc configuration [here](https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_sign_in/v2.0/.well-known/openid-configuration)).

This pull request  proposes a new variable `OIDC_IGNORE_USERINFO_URL` in order to ignore this endpoint and use directly the Azure B2C return that contains the user's information (once decoded). 

It also adds a variable   `OIDC_EMAIL_CLAIM_KEY` to specify the key for the email because for Azure B2C it's not `email` but `emails`.

Links: 
- [Microsoft doc](https://docs.microsoft.com/en-us/azure/active-directory-b2c/openid-connect)