### PR TITLE
Fix checks for claims parameter supported

### DIFF
--- a/oauth2_authcodeflow/views.py
+++ b/oauth2_authcodeflow/views.py
@@ -97,7 +97,7 @@ class AuthenticateView(CacheBaseView, UrlParamsMixin):
         return next_url, failure_url
 
     def get_claims_parameter(self, request: HttpRequest) -> Optional[Dict[str, str]]:
-        if request.session.get(constants.OIDC_CLAIMS_PARAMETER_SUPPORTED, False):
+        if request.session.get(constants.SESSION_OP_CLAIMS_PARAMETER_SUPPORTED, False):
             claims_parameter = {}
             if settings.OIDC_RP_USERINFO_CLAIMS:
                 claims_parameter['userinfo'] = settings.OIDC_RP_USERINFO_CLAIMS

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -144,9 +144,9 @@ class TestAuthenticateView:
         settings.OIDC_RP_USERINFO_CLAIMS = {}
         settings.OIDC_RP_TOKEN_CLAIMS = {}
         assert view.get_claims_parameter(request) is None
-        session[constants.OIDC_CLAIMS_PARAMETER_SUPPORTED] = False
+        session[constants.SESSION_OP_CLAIMS_PARAMETER_SUPPORTED] = False
         assert view.get_claims_parameter(request) is None
-        session[constants.OIDC_CLAIMS_PARAMETER_SUPPORTED] = True
+        session[constants.SESSION_OP_CLAIMS_PARAMETER_SUPPORTED] = True
         assert view.get_claims_parameter(request) is None
         settings.OIDC_RP_USERINFO_CLAIMS = {'is_admin': None}
         assert view.get_claims_parameter(request) == {'userinfo': {'is_admin': None}}


### PR DESCRIPTION
get_oidc_urls() populates the session with SESSION_OP_CLAIMS_PARAMETER_SUPPORTED but views.py checks for OIDC_CLAIMS_PARAMETER_SUPPORTED (and its tests populate that). So the claims support code path is never taken.

Presumably the intention is to use SESSION_OP_CLAIMS_PARAMETER_SUPPORTED.