### PR TITLE
auth - build_token_request_params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ reports/
 .coverage
 .venv/
 .cache/
+.idea/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Specific OIDC settings:
 | `OIDC_OP_JWKS_URL` | URL of your OpenId connect Provider endpoint to get public signing keys (in `PEM` or `DER` format).<br>This is used to verify the `id_token`.<br>This is **not recommended** to provide this url here but rather use `OIDC_OP_DISCOVERY_DOCUMENT_URL` config. | `None` |
 | `OIDC_OP_END_SESSION_URL` | URL of your OpenID connect Provider end session endpoint (not recommended, `OIDC_OP_DISCOVERY_DOCUMENT_URL` is preferred). | `None` |
 | `OIDC_OP_FETCH_USER_INFO` | Fetch user info on login or not. | `True` |
+| `OIDC_OP_PKCE_ALLOW_SEND_SECRET` | remove `client_secret` param from the request for the token when PKCE flow is used. | `True` |
 | `OIDC_OP_TOTAL_LOGOUT` | Do a call to total logout will call the OP for a logout. Default true.<br>Be careful, some OP will not follow the RFC and will not allow the user to NOT logout all connected apps.<br>Azure is such a bad example. | `True` |
 | `OIDC_OP_EXPECTED_EMAIL_CLAIM` | expected email key. | `'email'` |
 | `OIDC_OP_EXPECTED_CLAIMS` | `OIDC_OP_EXPECTED_EMAIL_CLAIM` value is automatically included in this list. | `[]` |

--- a/oauth2_authcodeflow/conf.py
+++ b/oauth2_authcodeflow/conf.py
@@ -59,6 +59,9 @@ DEFAULTS: Dict[str, Tuple[Any, Any]] = {
     'OIDC_OP_END_SESSION_URL': (str, None),
     # Fetch user info on login or not.
     'OIDC_OP_FETCH_USER_INFO': (bool, True),
+    # avoid `client_secret` param in the request for the token when PKCE flow is used
+    # It depends on the configuration of your OpenID connect Provider token endpoint.
+    'OIDC_OP_PKCE_ALLOW_SEND_SECRET': (bool, True),
     # Do a call to total logout will call the OP for a logout. Default true.
     # Be careful, some OP will not follow the RFC and will not allow the user to NOT logout all connected apps.
     # Azure is such a bad example.


### PR DESCRIPTION
Refactored authenticate_oauth2 method to use build_token_request_params in auth module to isolate the logic of the selection of the params.
Added `OIDC_OP_PKCE_ALLOW_SEND_SECRET`configuration entry (default is`True` for retrocompatibility) to send or not the client_secret instead of relying on an empty value. 
Added description of the new configuration entry
Added tests for build_token_request_params method
Closes #18 